### PR TITLE
Optimize image handling: convert PNGs to WebP, drop AVIF format

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -25,7 +25,10 @@ const nextConfig = {
   images: {
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
-    formats: ['image/avif', 'image/webp'],
+    // WebP only — dropping AVIF avoids the heavy Sharp encode that was
+    // OOM-killing the container during cold-cache warm-up after deploy.
+    // The size delta vs AVIF is small for these already-optimized sources.
+    formats: ['image/webp'],
     qualities: [75, 80], // Allowed quality values for next/image
     minimumCacheTTL: 604800,
   },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,6 +13,13 @@ const nextConfig = {
         destination: 'https://brendanciccone.com/:path*',
         permanent: true,
       },
+      // Mockup PNGs were converted to WebP. Keep cached HTML, indexed URLs,
+      // and shared social-media links resolving until they're refreshed.
+      {
+        source: '/work/:project/:filename.png',
+        destination: '/work/:project/:filename.webp',
+        permanent: true,
+      },
     ]
   },
   images: {


### PR DESCRIPTION
## Summary
This PR optimizes image handling by converting mockup PNGs to WebP format and removing AVIF from the supported image formats to improve build performance and reduce memory usage.

## Key Changes
- **PNG to WebP redirect**: Added a permanent redirect rule to serve WebP versions of PNG mockup images at `/work/:project/:filename.webp`, maintaining compatibility with cached HTML, indexed URLs, and social media links
- **Removed AVIF format**: Changed image formats from `['image/avif', 'image/webp']` to `['image/webp']` only
  - Eliminates the heavy Sharp encoding process that was causing out-of-memory errors during cold-cache warm-up after deployment
  - File size delta between WebP and AVIF is minimal for already-optimized sources

## Implementation Details
- The redirect uses `permanent: true` to ensure search engines and caches update to the new WebP URLs
- WebP format alone provides sufficient compression while being significantly faster to encode than AVIF
- This change reduces deployment-time memory pressure while maintaining image quality

https://claude.ai/code/session_01BR1HsvteRJs2cqQd9L8A8h