### PR TITLE
Fix broken client-side navigation (trailingSlash export)

### DIFF
--- a/__tests__/metadata.test.ts
+++ b/__tests__/metadata.test.ts
@@ -16,7 +16,7 @@ describe('generatePageMetadata', () => {
   it('constructs full URL from path', () => {
     const meta = generatePageMetadata({ path: '/about' })
     const og = meta.openGraph as Record<string, unknown>
-    expect(og.url).toBe('https://brendanciccone.com/about')
+    expect(og.url).toBe('https://brendanciccone.com/about/')
   })
 
   it('sets alternates canonical to apex path (resolved with metadataBase)', () => {
@@ -24,7 +24,7 @@ describe('generatePageMetadata', () => {
     expect(home.alternates?.canonical).toBe('/')
 
     const about = generatePageMetadata({ path: '/about' })
-    expect(about.alternates?.canonical).toBe('/about')
+    expect(about.alternates?.canonical).toBe('/about/')
   })
 
   it('includes OpenGraph and Twitter card metadata', () => {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,45 +7,46 @@ export const dynamic = 'force-static'
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = 'https://brendanciccone.com'
   
+  // Trailing slashes match the canonical URLs emitted under trailingSlash: true.
   return [
     {
-      url: `${baseUrl}`,
+      url: `${baseUrl}/`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 1,
     },
     {
-      url: `${baseUrl}/about`,
+      url: `${baseUrl}/about/`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
-      url: `${baseUrl}/contact`,
+      url: `${baseUrl}/contact/`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
-      url: `${baseUrl}/work/corellium`,
+      url: `${baseUrl}/work/corellium/`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.9,
     },
     {
-      url: `${baseUrl}/work/spontivly`,
+      url: `${baseUrl}/work/spontivly/`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.9,
     },
     {
-      url: `${baseUrl}/work/immertec`,
+      url: `${baseUrl}/work/immertec/`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.9,
     },
     {
-      url: `${baseUrl}/work/paidly`,
+      url: `${baseUrl}/work/paidly/`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.9,

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -56,6 +56,14 @@ type PageMetadataParams = {
   imageHeight?: number;
 };
 
+// Normalize a route path to its trailing-slash directory form ('' → '/',
+// '/about' → '/about/'). Matches the URLs Next emits under trailingSlash: true.
+const toTrailingSlashPath = (path: string): string => {
+  if (path === '' || path === '/') return '/';
+  const withLeadingSlash = path.startsWith('/') ? path : `/${path}`;
+  return withLeadingSlash.endsWith('/') ? withLeadingSlash : `${withLeadingSlash}/`;
+};
+
 /**
  * Generate standardized metadata for a page
  */
@@ -68,13 +76,15 @@ export function generatePageMetadata({
   imageWidth = 1024,
   imageHeight = 537,
 }: PageMetadataParams): Metadata {
-  const pageTitle = title 
+  const pageTitle = title
     ? `${title} - Brendan Ciccone - 0 → 1 Staff Product Designer`
     : "Brendan Ciccone - 0 → 1 Staff Product Designer";
-  
-  const url = `${baseMetadata.baseUrl}${path}`;
-  const canonicalPath =
-    path === '' ? '/' : path.startsWith('/') ? path : `/${path}`;
+
+  // next.config sets trailingSlash: true, so every route resolves to a
+  // directory URL (e.g. /about/). Keep canonical + og:url consistent with that
+  // so search engines aren't pointed at a URL that 308-redirects.
+  const canonicalPath = toTrailingSlashPath(path);
+  const url = `${baseMetadata.baseUrl}${canonicalPath}`;
 
   return {
     title: pageTitle,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,12 @@ const nextConfig = {
   //  - image Cache-Control headers live in public/_headers
   // See DEPLOY.md for the dashboard pieces.
   output: 'export',
+  // Emit a directory with index.html per route (out/about/index.html) instead
+  // of out/about.html. The flat-file layout collides with the per-route RSC
+  // payload directories (out/about/) that App Router export also emits, which
+  // breaks client-side <Link> navigation on static hosts (Cloudflare Workers
+  // assets). Trailing-slash directories resolve unambiguously.
+  trailingSlash: true,
   turbopack: {},
   images: {
     // Cloudflare Image Transformations replace the built-in optimizer, which


### PR DESCRIPTION
## Problem

On the deployed site, clicking internal `<Link>`s did nothing — the URL didn't change. Full-page loads (typing a URL) and external links worked; in-app client-side navigation didn't.

## Cause

Next.js App Router with `output: 'export'` and the default (no trailing slash) emits a **flat file** `out/about.html` *alongside* a **directory** `out/about/` that holds the route's RSC payload `.txt` files. That file-vs-directory collision resolves fine for hard navigation but breaks the client router's soft navigation on static asset hosts (Cloudflare Workers static assets).

## Fix

Set `trailingSlash: true` so each route emits `out/about/index.html` — one unambiguous directory per route, which static hosts resolve natively.

Verified against the real Cloudflare asset engine (`wrangler dev`):
- `/about/` → 200 (serves the page)
- legacy `/about` → 307 redirect to `/about/`
- RSC payloads (`/about/__next.about.__PAGE__.txt`) → 200

Canonical tags, `og:url`, and `sitemap.xml` updated to the trailing-slash form so search engines aren't pointed at a URL that redirects. Tests updated; full suite green (25/25).

## Note

URLs now end in `/` (e.g. `/about/`). Cloudflare 308/307-redirects the old form automatically, so existing links keep working.

https://claude.ai/code/session_01Dy64bet57ihXouda4ne22P

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy64bet57ihXouda4ne22P)_