### PR TITLE
Fix dead header/CTA navigation (drop prefetch on static export)

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -99,7 +99,6 @@ export default function Header() {
                             : "bg-transparent text-muted-foreground hover:text-foreground hover:bg-muted/50"
                         }`}
                         aria-current={active ? "page" : undefined}
-                        prefetch={true}
                       >
                         {item.label}
                       </Link>
@@ -148,7 +147,6 @@ export default function Header() {
                           : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
                       }`}
                       aria-current={active ? "page" : undefined}
-                      prefetch={true}
                       tabIndex={mobileMenuOpen ? 0 : -1}
                     >
                       {item.label}


### PR DESCRIPTION
## Problem

After the trailingSlash fix, work pages navigated but the header **About** and **Contact** links were still dead — and so was the **"Reach out"** CTA on every work page.

## Cause

The header nav used `prefetch={true}`. Under `output: 'export'` on Next 16, an explicit full prefetch requests a segment-data variant that isn't emitted as a static file, so it 404s and the router caches the route as unreachable. Because the header renders on **every** page, that poisoned `/about/` and `/contact/` globally — breaking not just the header links but every link to those routes, including the work-page "Reach out" CTA (`<Link href="/contact">`, which has no prefetch of its own).

## Fix

Drop the explicit `prefetch={true}` so the header links use Next's default auto-prefetch — the same behavior as the work-card links that already navigate correctly.

Verified in a real headless browser against the Cloudflare asset engine (`wrangler dev`):
- Header About / Contact (from home and from a work page) → navigate ✓
- Work-page "Reach out" CTA → `/contact/` ✓
- Header home logo → `/` ✓
- No page errors

Tests green (25/25).

https://claude.ai/code/session_01Dy64bet57ihXouda4ne22P

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dy64bet57ihXouda4ne22P)_