### PR TITLE
Nav cross-fades, 300ms morph token, centered case rail, footer mark fix

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -86,13 +86,15 @@
  * Motion grammar — the whole site moves as one material. Three durations,
  * one signature curve:
  *   touch  (150ms) — color/opacity feedback: hovers, presses
- *   settle (200ms) — anything that physically moves: lifts, wipes, morphs
+ *   settle (200ms) — anything that physically moves: lifts, wipes
+ *   morph  (300ms) — cross-page shared-element view transitions
  *   enter  (450ms) — page-load entrances only
  * The stamp accent (250ms) is the single deliberate exception.
  */
 :root {
   --motion-touch: 150ms;
   --motion-settle: 200ms;
+  --motion-morph: 300ms;
   --motion-enter: 450ms;
   --ease-settle: cubic-bezier(0.22, 1, 0.36, 1);
 }
@@ -398,7 +400,7 @@ body {
   }
 
   ::view-transition-group(*) {
-    animation-duration: var(--motion-settle);
+    animation-duration: var(--motion-morph);
     animation-timing-function: var(--ease-settle);
   }
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -8,7 +8,9 @@ export default function Footer() {
       <div className="text-xs font-mono text-muted-foreground uppercase tracking-[0.1em] flex items-center gap-1">
         <span className="text-sm leading-none">&copy;</span>
         <span>
-          {currentYear} Brendan Ciccone<span className="text-primary font-semibold">.</span>
+          {/* The mark: Archivo's period is the square; the footer's mono face
+              would render it as a round dot */}
+          {currentYear} Brendan Ciccone<span className="text-primary font-heading font-extrabold">.</span>
         </span>
       </div>
       <div className="flex gap-4">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Image from "next/image"
-import Link from "next/link"
+import { TransitionLink } from "@/components/view-transition-link"
 import { usePathname } from "next/navigation"
 import { useState, type KeyboardEvent } from "react"
 import { cn } from "@/lib/utils"
@@ -35,7 +35,7 @@ export default function Header() {
     <header className="fixed top-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-sm border-b border-border">
       <div className="max-w-[1024px] mx-auto px-5">
         <div className="flex h-14 items-center justify-between">
-          <Link
+          <TransitionLink
             href="/"
             aria-label="Brendan Ciccone — home"
             className="flex items-center gap-2.5"
@@ -54,7 +54,7 @@ export default function Header() {
             <span className="font-heading font-extrabold uppercase tracking-[-0.01em] text-sm sm:text-base">
               Brendan Ciccone
             </span>
-          </Link>
+          </TransitionLink>
 
           {/* Desktop nav */}
           <nav className="hidden md:block" aria-label="Main Navigation">
@@ -62,7 +62,7 @@ export default function Header() {
               {navItems.map((item) => {
                 const active = isActive(pathname, item.href)
                 return (
-                  <Link
+                  <TransitionLink
                     key={item.href}
                     href={item.href}
                     className={cn(
@@ -74,7 +74,7 @@ export default function Header() {
                     aria-current={active ? "page" : undefined}
                   >
                     {item.label}
-                  </Link>
+                  </TransitionLink>
                 )
               })}
             </div>
@@ -129,7 +129,7 @@ export default function Header() {
             {navItems.map((item) => {
               const active = isActive(pathname, item.href)
               return (
-                <Link
+                <TransitionLink
                   key={item.href}
                   href={item.href}
                   className={cn(
@@ -143,7 +143,7 @@ export default function Header() {
                   onClick={() => setMobileMenuOpen(false)}
                 >
                   {item.label}
-                </Link>
+                </TransitionLink>
               )
             })}
           </div>

--- a/components/section-nav.tsx
+++ b/components/section-nav.tsx
@@ -13,6 +13,13 @@ export interface SectionNavItem {
 /*
  * Fixed side rail for case-study sections. Only rendered at xl+ where the
  * viewport margin outside the 1024px content column can hold it.
+ *
+ * The rail is anchored to that column rather than the viewport edge: 512px
+ * (half the column) + 104px (rail width) + 48px (gutter) = the 664px offset
+ * from centre. Pinned to the viewport instead, the gap would widen with the
+ * screen — roughly 300px at 1920 and 600px at 2560 — stranding the rail by
+ * the bezel, far from the text it indexes. The max() floor keeps it on-screen
+ * at the xl breakpoint, where the margin is only just wide enough.
  */
 export const SectionNav = ({ items }: { items: readonly SectionNavItem[] }): React.JSX.Element => {
   const [activeId, setActiveId] = useState<string | null>(null)
@@ -43,7 +50,7 @@ export const SectionNav = ({ items }: { items: readonly SectionNavItem[] }): Rea
   return (
     <nav
       aria-label="Case study sections"
-      className="hidden xl:block fixed left-6 2xl:left-12 top-1/2 -translate-y-1/2 z-40"
+      className="hidden xl:block fixed left-[max(1.5rem,calc(50%_-_664px))] top-1/2 -translate-y-1/2 z-40"
     >
       <ul className="flex flex-col gap-3 max-w-[104px]">
         {items.map((item) => {

--- a/components/section-nav.tsx
+++ b/components/section-nav.tsx
@@ -43,7 +43,7 @@ export const SectionNav = ({ items }: { items: readonly SectionNavItem[] }): Rea
   return (
     <nav
       aria-label="Case study sections"
-      className="hidden xl:block fixed left-6 2xl:left-12 top-28 z-40"
+      className="hidden xl:block fixed left-6 2xl:left-12 top-1/2 -translate-y-1/2 z-40"
     >
       <ul className="flex flex-col gap-3 max-w-[104px]">
         {items.map((item) => {

--- a/components/view-transition-link.tsx
+++ b/components/view-transition-link.tsx
@@ -30,21 +30,24 @@ export const ViewTransitionSettler = (): null => {
   return null
 }
 
-interface TransitionLinkProps {
-  href: string
-  className?: string
-  children: React.ReactNode
-}
+/* Accepts everything next/link does, but href stays a plain string so the
+   same-page guard below can compare it against the current pathname */
+type TransitionLinkProps = Omit<React.ComponentProps<typeof Link>, "href"> & { href: string }
 
-export const TransitionLink = ({ href, className, children }: TransitionLinkProps): React.JSX.Element => {
+export const TransitionLink = ({ href, onClick, children, ...rest }: TransitionLinkProps): React.JSX.Element => {
   const router = useRouter()
+  const pathname = usePathname()
 
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event)
     // Let modified clicks (new tab etc.) and unsupported browsers use the
     // default Link behavior
     if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) return
     if (typeof document.startViewTransition !== "function") return
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return
+    // Same-page clicks never settle (pathname doesn't change) — skip the
+    // transition rather than holding the snapshot until the failsafe fires
+    if (pathname === href) return
 
     event.preventDefault()
     document.startViewTransition(() => {
@@ -62,7 +65,7 @@ export const TransitionLink = ({ href, className, children }: TransitionLinkProp
   }
 
   return (
-    <Link href={href} className={className} onClick={handleClick}>
+    <Link href={href} onClick={handleClick} {...rest}>
       {children}
     </Link>
   )

--- a/components/view-transition-link.tsx
+++ b/components/view-transition-link.tsx
@@ -45,11 +45,19 @@ export const TransitionLink = ({ href, onClick, children, ...rest }: TransitionL
     if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) return
     if (typeof document.startViewTransition !== "function") return
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return
+    // Links that open outside this document aren't client navigations
+    if (rest.target && rest.target !== "_self") return
+    // Guards the parse below; every browser with startViewTransition has it
+    if (!URL.canParse(href, window.location.href)) return
+
+    const destination = new URL(href, window.location.href)
+    // Cross-origin hrefs leave the app entirely — let the browser navigate
+    if (destination.origin !== window.location.origin) return
     // Same-page clicks never settle (pathname doesn't change) — skip the
     // transition rather than holding the snapshot until the failsafe fires.
-    // Compare pathnames only, so query/hash variants of the current route
-    // (/about?tab=2, /about#details) are also caught.
-    if (new URL(href, window.location.href).pathname === pathname) return
+    // Comparing pathnames catches query/hash variants of the current route
+    // (/about?tab=2, /about#details) too.
+    if (destination.pathname === pathname) return
 
     event.preventDefault()
     document.startViewTransition(() => {

--- a/components/view-transition-link.tsx
+++ b/components/view-transition-link.tsx
@@ -46,8 +46,10 @@ export const TransitionLink = ({ href, onClick, children, ...rest }: TransitionL
     if (typeof document.startViewTransition !== "function") return
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return
     // Same-page clicks never settle (pathname doesn't change) — skip the
-    // transition rather than holding the snapshot until the failsafe fires
-    if (pathname === href) return
+    // transition rather than holding the snapshot until the failsafe fires.
+    // Compare pathnames only, so query/hash variants of the current route
+    // (/about?tab=2, /about#details) are also caught.
+    if (new URL(href, window.location.href).pathname === pathname) return
 
     event.preventDefault()
     document.startViewTransition(() => {


### PR DESCRIPTION
## What this does

Lands the final refinement commit that missed the #42 merge window, plus one glyph fix.

### Cherry-picked from the polish branch (pushed after #42 merged)
- **Every header navigation cross-fades** — logo, desktop nav, and mobile menu route through `TransitionLink`, so internal page changes transition instead of hard-cutting. Biggest smoothness win on touch, where the hover layer never fires. Same-page clicks skip the transition (they never settle, so they'd hold the snapshot until the failsafe).
- **`--motion-morph` token (300ms)** for cross-page shared-element transitions — 200ms settle read abrupt across pages; now it's a documented part of the motion grammar rather than a magic value.
- **Case-study section rail centers vertically** in the viewport margin, reading as a position gauge rather than fixed content.

### New
- **Footer mark fix:** the copyright period was set in the mono face, whose period renders as a round dot — everywhere else the mark is Archivo 800's square. The glyph now uses the heading face, so the identity mark is consistent sitewide.

## Test plan
- [x] `pnpm lint` — 0 problems
- [x] `tsc --noEmit` — clean
- [x] `pnpm test` — 20/20
- [x] Verified on localhost, desktop + mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)