### PR TITLE
Fix mobile Safari animation jitter and funky page-transition cut-off

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -277,20 +277,43 @@ body {
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .anim-rise {
+  /*
+   * Entrance choreography plays on first load only. Once the app has done a
+   * client navigation (TransitionLink sets [data-navigated] on <html>), the
+   * same-document view transition IS the entrance — replaying a per-element
+   * rise on top of it made the incoming page's single-frame snapshot capture
+   * these elements mid-animation (still at opacity 0, translated, or inside
+   * their delay). That's the mobile "cut off, then suddenly appears": the
+   * snapshot showed them blank, then the real DOM finished rising after the
+   * morph. Gating to the un-navigated document keeps the fresh-load feel
+   * while letting the morph own navigation. The hero frame is the sharpest
+   * case — it carries both anim-rise and a view-transition-name, so the
+   * shared-element morph was fighting a transform entrance on the same node.
+   *
+   * will-change + backface-visibility promote each animated element to its
+   * own compositing layer so Safari rasterizes the moving text once instead
+   * of every frame — the fix for the "not buttery smooth" jitter on mobile.
+   */
+  :root:not([data-navigated]) .anim-rise {
     animation: rise-in var(--motion-enter) var(--ease-settle) both;
+    will-change: transform, opacity;
+    backface-visibility: hidden;
   }
 
   /* The red period stamps in as the headline settles — grow-in is an
      in-place entrance with no direction, so it can't fight the page's
      motion if it lands while the user is already scrolling */
-  .anim-stamp {
+  :root:not([data-navigated]) .anim-stamp {
     animation: grow-in 250ms var(--ease-settle) 550ms both;
+    will-change: transform, opacity;
+    backface-visibility: hidden;
   }
 
   .anim-rule {
     transform-origin: left;
     animation: draw-rule 550ms var(--ease-settle) 250ms both;
+    will-change: transform;
+    backface-visibility: hidden;
   }
 
   /*
@@ -309,9 +332,12 @@ body {
     animation-delay: 0ms;
   }
 
-  /* Dot-grid cascade; per-dot delay set inline */
-  .anim-dot {
+  /* Dot-grid cascade; per-dot delay set inline. Load-only, same reasoning as
+     the rise/stamp entrances above. */
+  :root:not([data-navigated]) .anim-dot {
     animation: rise-in 350ms var(--ease-settle) both;
+    will-change: transform, opacity;
+    backface-visibility: hidden;
   }
 
 }

--- a/components/view-transition-link.tsx
+++ b/components/view-transition-link.tsx
@@ -60,6 +60,12 @@ export const TransitionLink = ({ href, onClick, children, ...rest }: TransitionL
     if (destination.pathname === pathname) return
 
     event.preventDefault()
+    // Mark the document as navigated so the incoming route's mount-entrance
+    // animations (anim-rise/stamp/dot) are suppressed — see globals.css. Set
+    // synchronously before the transition starts so the new page mounts with
+    // the flag already present, letting the morph capture it at final state
+    // instead of mid-rise. Stays set for the session; a full reload clears it.
+    document.documentElement.dataset.navigated = "true"
     document.startViewTransition(() => {
       const settled = new Promise<void>((resolve) => {
         settleNavigation = resolve

--- a/components/view-transition-link.tsx
+++ b/components/view-transition-link.tsx
@@ -40,14 +40,12 @@ export const TransitionLink = ({ href, onClick, children, ...rest }: TransitionL
 
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     onClick?.(event)
-    // Let modified clicks (new tab etc.) and unsupported browsers use the
-    // default Link behavior
+    // Let modified clicks (new tab etc.) use the default Link behavior
     if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) return
-    if (typeof document.startViewTransition !== "function") return
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return
     // Links that open outside this document aren't client navigations
     if (rest.target && rest.target !== "_self") return
-    // Guards the parse below; every browser with startViewTransition has it
+    // Guards the parse below; URL.canParse is Baseline alongside the view
+    // transition API this handler upgrades to
     if (!URL.canParse(href, window.location.href)) return
 
     const destination = new URL(href, window.location.href)
@@ -56,17 +54,29 @@ export const TransitionLink = ({ href, onClick, children, ...rest }: TransitionL
     // Same-page clicks never settle (pathname doesn't change) — skip the
     // transition rather than holding the snapshot until the failsafe fires.
     // Comparing pathnames catches query/hash variants of the current route
-    // (/about?tab=2, /about#details) too.
+    // (/about?tab=2, /about#details) too. Kept ahead of the marker below so a
+    // same-page click never snaps a still-running first-load entrance.
     if (destination.pathname === pathname) return
 
+    // Browsers without view transitions, and reduced-motion users, get a plain
+    // client-side Link navigation. Mark it navigated here so the incoming route
+    // renders its mount entrances (anim-rise/stamp/dot) at final state instead
+    // of replaying them — see globals.css. (Reduced-motion entrances are
+    // already inert; marking is harmless and keeps the fallback uniform.)
+    if (typeof document.startViewTransition !== "function" || window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      document.documentElement.dataset.navigated = "true"
+      return
+    }
+
     event.preventDefault()
-    // Mark the document as navigated so the incoming route's mount-entrance
-    // animations (anim-rise/stamp/dot) are suppressed — see globals.css. Set
-    // synchronously before the transition starts so the new page mounts with
-    // the flag already present, letting the morph capture it at final state
-    // instead of mid-rise. Stays set for the session; a full reload clears it.
-    document.documentElement.dataset.navigated = "true"
     document.startViewTransition(() => {
+      // Mark inside the update callback so the flag lands on the NEW document
+      // state only: the outgoing snapshot is already captured by the time this
+      // runs, so a click during a still-running first-load entrance can't snap
+      // the old page. Set before router.push so the incoming route mounts
+      // already marked and its entrances stay at their final state. Stays set
+      // for the session; a reload clears it.
+      document.documentElement.dataset.navigated = "true"
       const settled = new Promise<void>((resolve) => {
         settleNavigation = resolve
       })


### PR DESCRIPTION
## Summary

Fixes two mobile issues reported on Safari, both rooted in the entrance-animation layer:

1. **Animations feel jittery / not buttery smooth.** The entrance animations (`.anim-rise`, `.anim-stamp`, `.anim-dot`) animate `transform` + `opacity` on text and images without promoting those elements to their own compositing layer. iOS Safari then re-rasterizes the sub-pixel-positioned text every frame → shimmer. Added `will-change` + `backface-visibility: hidden` so each moving element is rasterized once and composited — the standard fix for choppy transform animations on Safari.

2. **Page switches look "cut off, then suddenly appear."** Every case-study hero frame carries **both** `anim-rise` and a `view-transition-name` (e.g. `app/work/corellium/page.tsx:69`), and the page headers use `anim-rise` too. A same-document view transition snapshots the incoming page in a single frame, catching those elements mid-entrance (opacity 0, translated, or still inside their `animation-delay`) — so the page flashed in blank/cut-off, then the real DOM finished rising after the morph. The shared hero was the worst case: the morph and a transform entrance were fighting over the same node.

## Approach

Entrance choreography now plays on **first load only**. `TransitionLink` stamps `[data-navigated]` on `<html>` before starting the transition, so the incoming route (and the shared hero) render at their final state when the morph captures them. The view transition becomes the sole entrance for client navigations; a fresh load / refresh still gets the full rise-and-stamp choreography. This matches the existing code intent that these are "page-load entrances."

`.anim-rule` (DrawnRule) is intentionally left ungated so its scroll-triggered draw still works after navigation.

## Trade-off

On navigation you no longer get the per-element rise — the morph/cross-fade is the whole motion. That's what makes it smooth. Keeping *some* entrance on navigation would require orchestrating it to start after the transition finishes (more JS); happy to do that as a follow-up if preferred.

## Testing

- `pnpm lint` — clean
- `pnpm test` — 20/20 pass
- `pnpm build` — succeeds

Note: not verified on a physical iOS device. Both fixes use standard, well-understood mechanisms (compositor promotion; avoiding mid-animation snapshots), but on-device confirmation is recommended. If residual jank remains during *scrolling* specifically, the next suspect is the `backdrop-blur-sm` on the fixed header (`components/header.tsx:35`), left untouched here as a deliberate design choice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBh1N93Ej7mAENmHF2p1dA)_