### PR TITLE
Resolve scroll flow nearer the bottom edge on short viewports

### DIFF
--- a/__tests__/scroll-flow-math.test.ts
+++ b/__tests__/scroll-flow-math.test.ts
@@ -6,12 +6,17 @@ import {
   enterRamp,
   parseFlowFactor,
   shouldReleaseWipe,
+  MIN_RAMP_HEIGHT,
   OFFSCREEN_MARGIN,
   WIPE_TRIGGER_RATIO,
   type FlowRect,
 } from "@/lib/scroll-flow-math"
 
-/* A typical desktop viewport; every expectation below is relative to it */
+/*
+ * A typical laptop window; every expectation below is relative to it. Note it
+ * sits inside the band where enterRamp interpolates, so it is deliberately not
+ * the viewport the tall-anchor test uses.
+ */
 const H = 860
 /* A phone in Safari with the bars expanded, which is the shortest viewport
  * real visitors arrive on in portrait */
@@ -78,17 +83,24 @@ describe("enterRamp", () => {
     expect(settleOffset(PHONE_H)).toBeLessThan(settleOffset(H) / 2)
   })
 
-  it("tightens monotonically as the viewport shrinks", () => {
-    const offsets = [1000, 900, 850, 800, 750, 700, 600].map(settleOffset)
+  /*
+   * Non-strict on purpose: once MIN_RAMP_HEIGHT engages the settle offset is
+   * pinned flat, so the guarantee is that shrinking the viewport never *loosens*
+   * the ramp. The list runs through the floor rather than stopping above it,
+   * which is where an accidental strict assertion would pass by sampling luck.
+   */
+  it("never loosens as the viewport shrinks", () => {
+    const offsets = [1000, 900, 850, 800, 750, 700, 640, 600, 500, 390].map(settleOffset)
 
     for (const [index, offset] of offsets.slice(1).entries()) {
-      expect(offset).toBeLessThan(offsets[index])
+      expect(offset).toBeLessThanOrEqual(offsets[index])
     }
   })
 
   it("keeps a ramp long enough to read as motion on a landscape phone", () => {
     // A tenth of a 390px viewport would be 39px — a pop, not a rise
-    expect(enterRamp(390).height).toBeGreaterThanOrEqual(64)
+    expect(enterRamp(390).height).toBe(MIN_RAMP_HEIGHT)
+    expect(enterRamp(390).height).toBeGreaterThan(390 * 0.1)
   })
 
   it("never starts an element resolving before it has entered the viewport", () => {
@@ -172,6 +184,28 @@ describe("computeFlow", () => {
     expect(style.opacity).toBeCloseTo(1)
     expect(style.blurPx).toBe(0)
     expect(style.translateY).toBeCloseTo(0)
+  })
+
+  /*
+   * The rise composes with the page's own scroll, so it has to be a share of
+   * the ramp rather than a fixed distance. Held flat at 32px it made content
+   * overshoot half again as fast on a phone as on a desktop, purely because the
+   * ramp under it got shorter — invisible to every opacity-based assertion here,
+   * which is how it survived the first round.
+   */
+  it("rises at the same speed relative to the page on every viewport", () => {
+    const riseAtRampStart = (viewportHeight: number): number => {
+      const { start, height } = enterRamp(viewportHeight)
+      const atStart: FlowRect = { top: start, bottom: start + height }
+      const { translateY } = computeFlow(atStart, viewportHeight, viewportHeight * 5, 1)
+      // Element travels its own rise plus the ramp; the page travels the ramp
+      return (height + translateY) / height
+    }
+
+    const speeds = [1200, 900, 800, 715, 390].map(riseAtRampStart)
+    for (const speed of speeds) {
+      expect(speed).toBeCloseTo(speeds[0])
+    }
   })
 
   it("renders a page too short to scroll completely visible", () => {

--- a/__tests__/scroll-flow-math.test.ts
+++ b/__tests__/scroll-flow-math.test.ts
@@ -3,6 +3,7 @@ import {
   clamp01,
   computeFlow,
   computeRecede,
+  enterRamp,
   parseFlowFactor,
   shouldReleaseWipe,
   OFFSCREEN_MARGIN,
@@ -12,8 +13,17 @@ import {
 
 /* A typical desktop viewport; every expectation below is relative to it */
 const H = 860
+/* A phone in Safari with the bars expanded, which is the shortest viewport
+ * real visitors arrive on in portrait */
+const PHONE_H = 715
 /* Enough room left that the end-of-document floor never engages */
 const PLENTY_OF_SCROLL = H * 5
+
+/* How far above the bottom edge an element is finally free of the enter ramp */
+const settleOffset = (viewportHeight: number): number => {
+  const { start, height } = enterRamp(viewportHeight)
+  return viewportHeight - (start - height)
+}
 
 /* Rect sitting comfortably in the middle of the viewport */
 const settled: FlowRect = { top: H * 0.4, bottom: H * 0.7 }
@@ -46,6 +56,45 @@ describe("parseFlowFactor", () => {
     // k reaches the exit ramp as a divisor, so 0 would yield Infinity
     expect(parseFlowFactor("0")).toBe(1)
     expect(parseFlowFactor("-2")).toBe(1)
+  })
+})
+
+describe("enterRamp", () => {
+  it("holds the original geometry on a full-height window", () => {
+    const tall = 1000
+    const { start, height } = enterRamp(tall)
+
+    expect(start).toBeCloseTo(tall * 0.96)
+    expect(height).toBeCloseTo(tall * 0.2)
+  })
+
+  /*
+   * Regression for the mobile cut-off. Both numbers used to be flat fractions,
+   * so the dead band scaled with the screen and swallowed the bottom quarter of
+   * a phone — where the browser's own chrome already crowds the page.
+   */
+  it("finishes nearer the bottom edge the shorter the viewport gets", () => {
+    expect(settleOffset(PHONE_H)).toBeLessThan(100)
+    expect(settleOffset(PHONE_H)).toBeLessThan(settleOffset(H) / 2)
+  })
+
+  it("tightens monotonically as the viewport shrinks", () => {
+    const offsets = [1000, 900, 850, 800, 750, 700, 600].map(settleOffset)
+
+    for (const [index, offset] of offsets.slice(1).entries()) {
+      expect(offset).toBeLessThan(offsets[index])
+    }
+  })
+
+  it("keeps a ramp long enough to read as motion on a landscape phone", () => {
+    // A tenth of a 390px viewport would be 39px — a pop, not a rise
+    expect(enterRamp(390).height).toBeGreaterThanOrEqual(64)
+  })
+
+  it("never starts an element resolving before it has entered the viewport", () => {
+    for (const viewportHeight of [390, 600, 715, 800, 900, 1200]) {
+      expect(enterRamp(viewportHeight).start).toBeLessThanOrEqual(viewportHeight)
+    }
   })
 })
 
@@ -108,6 +157,21 @@ describe("computeFlow", () => {
     expect(atDocumentEnd.opacity).toBeCloseTo(1)
     expect(atDocumentEnd.blurPx).toBe(0)
     expect(atDocumentEnd.translateY).toBeCloseTo(0)
+  })
+
+  /*
+   * The bug this was reported as: on a phone the section heading below the hero
+   * sat ~120px above the bottom edge at two thirds opacity under a blur, and no
+   * amount of waiting resolved it because it was already as high as the page
+   * would take it.
+   */
+  it("fully resolves content sitting just above a phone's bottom edge", () => {
+    const heading: FlowRect = { top: PHONE_H - 120, bottom: PHONE_H - 90 }
+    const style = computeFlow(heading, PHONE_H, PHONE_H * 5, 1)
+
+    expect(style.opacity).toBeCloseTo(1)
+    expect(style.blurPx).toBe(0)
+    expect(style.translateY).toBeCloseTo(0)
   })
 
   it("renders a page too short to scroll completely visible", () => {

--- a/lib/scroll-flow-math.ts
+++ b/lib/scroll-flow-math.ts
@@ -40,7 +40,16 @@ const SHORT_VIEWPORT = 700
 /* No ramp shorter than this, however squat the window — below roughly a line
  * and a half of scroll the rise stops reading as motion and starts reading as
  * a pop */
-const MIN_RAMP_HEIGHT = 64
+export const MIN_RAMP_HEIGHT = 64
+/*
+ * How far an element rises on its way in, as a share of the ramp it rises
+ * over. A share rather than a fixed distance because the two compose: the
+ * element climbs its own rise on top of the page's scroll, so a constant
+ * distance over a variable ramp would make the same content overshoot faster
+ * on a phone than on a desktop. The ratio is the one a full-height window has
+ * always had — 32px across a 180px ramp — now held everywhere.
+ */
+const RISE_RATIO = 32 / 180
 
 export interface EnterRamp {
   /* Viewport offset at which an element begins resolving */
@@ -121,7 +130,7 @@ export const computeFlow = (
 
   return {
     opacity: visibility ** 1.15,
-    translateY: (1 - enter) * 32 - (1 - exit) * 26,
+    translateY: (1 - enter) * ramp.height * RISE_RATIO - (1 - exit) * 26,
     // Blur is by far the most expensive property here, so it is dropped
     // outright once the element has effectively settled rather than leaving a
     // 0.07px filter pinning it to a blur-capable layer for the rest of the scroll

--- a/lib/scroll-flow-math.ts
+++ b/lib/scroll-flow-math.ts
@@ -31,7 +31,50 @@ export interface RecedeStyle {
   translateY: number
 }
 
+/*
+ * Viewport heights the enter ramp is tuned against. Between them the geometry
+ * is interpolated; outside them it holds at the nearer anchor.
+ */
+const TALL_VIEWPORT = 900
+const SHORT_VIEWPORT = 700
+/* No ramp shorter than this, however squat the window — below roughly a line
+ * and a half of scroll the rise stops reading as motion and starts reading as
+ * a pop */
+const MIN_RAMP_HEIGHT = 64
+
+export interface EnterRamp {
+  /* Viewport offset at which an element begins resolving */
+  start: number
+  /* Distance it travels between invisible and fully resolved */
+  height: number
+}
+
 export const clamp01 = (value: number): number => Math.min(1, Math.max(0, value))
+
+/*
+ * Where the enter ramp starts and how long it runs, in pixels.
+ *
+ * Both used to be flat fractions of the viewport: begin at 0.96, finish 0.2
+ * later. On a full-height window that is a comfortable runway — a fifth of the
+ * screen to arrive in, settling a quarter of the way up. On a phone the same
+ * fractions describe most of what the reader can see at once: the lowest ~150px
+ * never resolved, and with the browser's own chrome sitting under them the page
+ * read as cut off rather than as in motion.
+ *
+ * So the fractions tighten as the viewport shortens — the ramp finishes nearer
+ * the bottom edge and spends less of the screen getting there — while a tall
+ * window keeps exactly the geometry it has always had.
+ */
+export const enterRamp = (viewportHeight: number): EnterRamp => {
+  const shortness = clamp01((TALL_VIEWPORT - viewportHeight) / (TALL_VIEWPORT - SHORT_VIEWPORT))
+  const startFraction = 0.96 + 0.04 * shortness
+  const rampFraction = 0.2 - 0.1 * shortness
+
+  return {
+    start: viewportHeight * startFraction,
+    height: Math.max(viewportHeight * rampFraction, MIN_RAMP_HEIGHT),
+  }
+}
 
 /*
  * `k` stretches the exit ramp. Lower means a later, shorter melt: the element
@@ -49,8 +92,8 @@ export const parseFlowFactor = (raw: string | undefined): number => {
 }
 
 /*
- * enter ramps over the bottom 20% of the viewport; exit melts the element as
- * its bottom edge approaches the header.
+ * enter ramps over the bottom of the viewport (see enterRamp for how much of
+ * it); exit melts the element as its bottom edge approaches the header.
  *
  * remainingScroll keeps the last element on the page honest. Whatever sits at
  * the bottom of the document can never climb out of the enter ramp, because
@@ -70,9 +113,9 @@ export const computeFlow = (
     return { opacity: 0, translateY: 0, blurPx: 0 }
   }
 
-  const rampHeight = viewportHeight * 0.2
-  const enterFloor = clamp01(1 - remainingScroll / rampHeight)
-  const enter = Math.max(clamp01((viewportHeight * 0.96 - rect.top) / rampHeight), enterFloor)
+  const ramp = enterRamp(viewportHeight)
+  const enterFloor = clamp01(1 - remainingScroll / ramp.height)
+  const enter = Math.max(clamp01((ramp.start - rect.top) / ramp.height), enterFloor)
   const exit = clamp01((rect.bottom - viewportHeight * 0.06) / (viewportHeight * 0.22 * k))
   const visibility = Math.min(enter, exit)
 


### PR DESCRIPTION
The enter ramp was two flat fractions of the viewport: elements began
resolving at 0.96 and finished 0.2 later, so nothing was ever fully
visible until its top cleared 76% of the screen. On a desktop window that
bottom quarter is a runway. On a phone it is roughly the last four lines
of the page, sitting directly on top of the browser's own chrome — the
section heading below the hero parked at 0.62 opacity under a 1.2px blur
and stayed there, which reads as the page being cut off rather than as
motion.

The fractions now tighten as the viewport shortens, interpolating between
a 900px anchor that keeps today's geometry exactly and a 700px anchor
that starts at the bottom edge and settles a tenth of the way up. The
ramp keeps a 64px floor so a landscape phone still gets a rise instead of
a pop.

### Which viewports this touches

Not phones only — the problem is geometric, so the fix is keyed to
viewport height rather than device class. Windows at 900px and taller are
byte-identical; everything shorter tightens, including the 750–870px
range where most laptop browser windows land.

| innerHeight | settle offset before | after |
|---|---|---|
| 900+ | 216px | unchanged |
| 860 | 206px | 182px |
| 800 | 192px | 136px |
| 750 | 180px | 101px |
| 715 (phone) | 172px | 79px |

The change is one-directional — it can only make content near the bottom
edge more resolved, never less — and touches only `opacity`, `filter`,
and `transform`, so there is no layout shift. The exit ramp, the melt at
the header, and the end-of-document footer rescue are untouched; the
footer was verified resolving at 715/800/900.

### Follow-up commit

The rise was a flat 32px while the ramp under it became variable, and the
two compose — an element climbs its own rise on top of the page's scroll.
Shortening the ramp therefore sped the rise up relative to the page:
1.42× scroll speed on a phone against 1.18× on a desktop, where it had
been a near-constant 1.18–1.25× everywhere before. The rise is now a
share of the ramp, pinned to the full-height ratio, so the speed is
identical on every screen. Opacity was unaffected, which is why no
existing assertion caught it.
