### PR TITLE
Migrate to Inter typeface and refactor scroll ramp geometry

### DIFF
--- a/__tests__/scroll-flow-math.test.ts
+++ b/__tests__/scroll-flow-math.test.ts
@@ -65,12 +65,15 @@ describe("parseFlowFactor", () => {
 })
 
 describe("enterRamp", () => {
-  it("holds the original geometry on a full-height window", () => {
+  it("ramps over a narrow band at the bottom of a full-height window", () => {
     const tall = 1000
     const { start, height } = enterRamp(tall)
 
     expect(start).toBeCloseTo(tall * 0.96)
-    expect(height).toBeCloseTo(tall * 0.2)
+    expect(height).toBeCloseTo(tall * 0.12)
+    // Resolved by the time it is this far up the screen — comfortably below
+    // reading height, which is the point of the band being short
+    expect(start - height).toBeGreaterThan(tall * 0.8)
   })
 
   /*

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,6 +4,7 @@ import { tools } from "@/components/tool-icons"
 import Link from "next/link"
 import Footer from "@/components/footer"
 import { DrawnRule } from "@/components/drawn-rule"
+import { StampPeriod } from "@/components/stamp-period"
 import { GitHubHeatmap } from "@/components/github-heatmap"
 import { SectionLabel } from "@/components/section-label"
 import { generatePageMetadata } from "@/lib/metadata"
@@ -231,7 +232,7 @@ export default function About() {
           <h1 data-recede="title" className="title-display text-[44px] sm:text-[60px]">
             <span className="anim-line-mask">
               <span className="block anim-line">
-                About<span className="text-primary inline-block anim-stamp">.</span>
+                About<StampPeriod className="anim-stamp" />
               </span>
             </span>
           </h1>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -4,6 +4,7 @@ import { DotGrid } from "@/components/dot-grid";
 import { DrawnRule } from "@/components/drawn-rule";
 import Header from "@/components/header";
 import Footer from "@/components/footer";
+import { StampPeriod } from "@/components/stamp-period";
 
 export const metadata = generatePageMetadata({
   title: "Contact",
@@ -29,7 +30,7 @@ export default function ContactPage() {
               <span className="anim-line-mask">
                 <span className="block anim-line [animation-delay:90ms]">
                   something <span className="text-primary">great</span>
-                  <span className="text-primary inline-block anim-stamp">.</span>
+                  <StampPeriod className="anim-stamp" />
                 </span>
               </span>
             </h1>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,14 +1,19 @@
 @import "tailwindcss";
 
 @theme {
-  /* Single-face system: every role resolves to Inter. The four tokens are kept
+  /* Single-face system: every role resolves to Inter. The three tokens are kept
      apart so the utilities that carry design intent (font-heading on display
      type, font-mono on the small uppercase meta labels) still say what they
-     mean, and so a second face could be reintroduced in one place. */
+     mean, and so a second face could be reintroduced in one place.
+     There is no --font-display: Tailwind only emits a theme variable that some
+     utility actually references, and nothing uses font-display — so the token
+     shipped as nothing at all, and any rule reading var(--font-display) was
+     silently invalid at computed-value time and inherited instead. Display type
+     runs on --font-heading, which the section labels, case-study titles and
+     stat values keep alive. */
   --font-sans: var(--font-inter);
   --font-heading: var(--font-inter);
   --font-mono: var(--font-inter);
-  --font-display: var(--font-inter);
 
   /* Clamped to 0px so the derived tokens don't go negative when --radius is 0. */
   --radius-lg: var(--radius);
@@ -469,9 +474,14 @@ body {
 /*
  * Title display utility — Inter 800, uppercase, tight leading. Used for the
  * hero h1s on home, about, and contact.
+ *
+ * Reads the semantic --font-heading rather than --font-inter directly, so a
+ * future display face swapped in at the token reaches these headings too. That
+ * depends on the token still being emitted, which holds as long as something
+ * in the markup uses a font-heading utility — see the @theme note above.
  */
 .title-display {
-  font-family: var(--font-inter), system-ui, sans-serif;
+  font-family: var(--font-heading), system-ui, sans-serif;
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: -0.02em;

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,12 +1,14 @@
 @import "tailwindcss";
 
 @theme {
-  --font-sans: var(--font-space-grotesk);
-  --font-heading: var(--font-archivo);
-  /* The reference's "mono" labels are actually Space Grotesk ("Space Grotesk,
-     monospace" stack) — so font-mono resolves to Space Grotesk on purpose. */
-  --font-mono: var(--font-space-grotesk);
-  --font-display: var(--font-archivo);
+  /* Single-face system: every role resolves to Inter. The four tokens are kept
+     apart so the utilities that carry design intent (font-heading on display
+     type, font-mono on the small uppercase meta labels) still say what they
+     mean, and so a second face could be reintroduced in one place. */
+  --font-sans: var(--font-inter);
+  --font-heading: var(--font-inter);
+  --font-mono: var(--font-inter);
+  --font-display: var(--font-inter);
 
   /* Clamped to 0px so the derived tokens don't go negative when --radius is 0. */
   --radius-lg: var(--radius);
@@ -217,8 +219,7 @@ html {
 
 /*
  * Note: no -webkit-font-smoothing: antialiased here — macOS antialiased
- * smoothing visibly thins Space Grotesk/Archivo; subpixel default keeps the
- * intended weight.
+ * smoothing visibly thins Inter; subpixel default keeps the intended weight.
  */
 body {
   @apply text-foreground min-h-screen relative;
@@ -231,8 +232,8 @@ body {
 }
 
 /*
- * Section header — Archivo label, hairline that fills the row, and an
- * optional mono accent counter appended in markup: [ 04 ].
+ * Section header — heading-weight label, hairline that fills the row, and an
+ * optional accent counter appended in markup: [ 04 ].
  */
 .sys-section-label {
   @apply text-sm font-heading font-extrabold uppercase tracking-[0.05em] text-foreground;
@@ -466,11 +467,11 @@ body {
 }
 
 /*
- * Title display utility — Archivo 800, uppercase, tight leading. Used for the
+ * Title display utility — Inter 800, uppercase, tight leading. Used for the
  * hero h1s on home, about, and contact.
  */
 .title-display {
-  font-family: var(--font-archivo), system-ui, sans-serif;
+  font-family: var(--font-inter), system-ui, sans-serif;
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: -0.02em;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Archivo, Space_Grotesk } from "next/font/google"
+import { Inter } from "next/font/google"
 import type React from "react"
 import type { Metadata, Viewport } from "next"
 import "./globals.css"
@@ -11,18 +11,13 @@ import { ReadingProgress } from "@/components/reading-progress"
 import { ViewTransitionSettler } from "@/components/view-transition-link"
 import JsonLd from "@/components/json-ld"
 
-// Swiss type system: Archivo for display/headings, Space Grotesk for
-// everything else — body, UI, and the small uppercase meta labels/tags/dates
-// (the static reference stacks those as "Space Grotesk, monospace").
-const archivo = Archivo({
+// One face for the whole site: Inter carries display, body, UI, and the small
+// uppercase meta labels/tags/dates alike. No weight list — Google serves Inter
+// as a variable font, so the full 100–900 range comes down in a single file and
+// the display weights (700/800) stay available.
+const inter = Inter({
   subsets: ["latin"],
-  weight: ["600", "700", "800"],
-  variable: "--font-archivo",
-})
-
-const spaceGrotesk = Space_Grotesk({
-  subsets: ["latin"],
-  variable: "--font-space-grotesk",
+  variable: "--font-inter",
 })
 
 export const viewport: Viewport = {
@@ -94,7 +89,7 @@ export default function RootLayout({
     // data-entrance ships on in the served HTML so a cold load plays its
     // choreography with no script involved and no flash of final state;
     // TransitionLink clears it for navigations that morph instead.
-    <html lang="en" suppressHydrationWarning data-entrance="" className={`${archivo.variable} ${spaceGrotesk.variable} ${spaceGrotesk.className}`}>
+    <html lang="en" suppressHydrationWarning data-entrance="" className={`${inter.variable} ${inter.className}`}>
       <head>
         <JsonLd />
       </head>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import Header from "@/components/header"
 import Footer from "@/components/footer"
+import { StampPeriod } from "@/components/stamp-period"
 
 export default function NotFound() {
   return (
@@ -20,7 +21,7 @@ export default function NotFound() {
             </div>
 
             <h1 className="title-display text-[44px] sm:text-6xl md:text-[72px] mt-6 anim-rise [animation-delay:100ms]">
-              Nothing here<span className="text-primary inline-block anim-stamp">.</span>
+              Nothing here<StampPeriod className="anim-stamp" />
             </h1>
 
             <p className="text-[15px] leading-[1.55] text-ink-soft mt-4 max-w-[440px] anim-rise [animation-delay:200ms]">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import Footer from "@/components/footer"
 import { CountUp } from "@/components/count-up"
 import { DrawnRule } from "@/components/drawn-rule"
 import { SectionLabel } from "@/components/section-label"
+import { StampPeriod } from "@/components/stamp-period"
 import { WorkCard, type WorkCardData } from "@/components/work-card"
 import { cn } from "@/lib/utils"
 
@@ -132,7 +133,7 @@ export default function Portfolio() {
               </span>
               <span className="anim-line-mask">
                 <span className="block anim-line [animation-delay:90ms]">
-                  Brendan<span className="text-primary inline-block anim-stamp">.</span>
+                  Brendan<StampPeriod className="anim-stamp" />
                 </span>
               </span>
             </h1>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -157,7 +157,15 @@ export default function Portfolio() {
                 )}
               >
                 <dt className="text-[11px] font-semibold uppercase tracking-[0.14em] text-primary">{stat.label}</dt>
-                <dd className="text-lg sm:text-[26px] font-heading font-bold leading-tight text-right sm:text-left tabular-nums">
+                {/* Sized so the longest value — "Staff Product Designer" — holds
+                    one line in a third of the container at every width the grid
+                    is live. At the full 1024px that phrase measures 288px against
+                    a 286px column at 26px, which is what wrapped it; the display
+                    tracking Inter wants at this size buys back the difference and
+                    the designed 26px survives on desktop. Below lg the column is
+                    genuinely too narrow for it, so the type steps down with the
+                    grid rather than breaking. */}
+                <dd className="text-lg sm:text-[14px] md:text-[18px] lg:text-[26px] font-heading font-bold leading-tight tracking-[-0.02em] text-right sm:text-left sm:whitespace-nowrap tabular-nums">
                   {stat.href ? (
                     <Link href={stat.href} target="_blank" rel="noopener noreferrer" className="hover:underline">
                       {stat.value}

--- a/components/contact-form.tsx
+++ b/components/contact-form.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
+import { StampPeriod } from "@/components/stamp-period"
 import { Send } from "lucide-react"
 import { z } from "zod"
 
@@ -181,7 +182,7 @@ export default function ContactForm() {
         className="w-full flex-1 flex flex-col justify-center gap-4"
       >
         <h3 className="title-display text-3xl sm:text-[40px] anim-rise">
-          Message sent<span className="text-primary inline-block anim-stamp">.</span>
+          Message sent<StampPeriod className="anim-stamp" />
         </h3>
         <p className="text-[15px] leading-[1.55] text-ink-soft anim-rise [animation-delay:100ms]">
           Thanks for reaching out. I&apos;ll get back to you shortly.

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -11,8 +11,8 @@ export default function Footer() {
       <div className="text-xs font-mono text-muted-foreground uppercase tracking-[0.1em] flex items-center gap-1">
         <span className="text-sm leading-none">&copy;</span>
         <span>
-          {/* The mark: Archivo's period is the square; the footer's mono face
-              would render it as a round dot */}
+          {/* The mark: the heaviest weight gives the period enough mass to read
+              as the square it is meant to be at this size */}
           {currentYear} Brendan Ciccone<span className="text-primary font-heading font-extrabold">.</span>
         </span>
       </div>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import { StampPeriod } from "@/components/stamp-period"
 
 export default function Footer() {
   const currentYear = new Date().getFullYear()
@@ -11,9 +12,7 @@ export default function Footer() {
       <div className="text-xs font-mono text-muted-foreground uppercase tracking-[0.1em] flex items-center gap-1">
         <span className="text-sm leading-none">&copy;</span>
         <span>
-          {/* The mark: the heaviest weight gives the period enough mass to read
-              as the square it is meant to be at this size */}
-          {currentYear} Brendan Ciccone<span className="text-primary font-heading font-extrabold">.</span>
+          {currentYear} Brendan Ciccone<StampPeriod />
         </span>
       </div>
       <div className="flex gap-4">

--- a/components/stamp-period.tsx
+++ b/components/stamp-period.tsx
@@ -1,3 +1,4 @@
+import type React from "react"
 import { cn } from "@/lib/utils"
 
 /*
@@ -17,7 +18,7 @@ import { cn } from "@/lib/utils"
  * optical correction for curves, and a square that used it would read as
  * sunken.
  */
-export const StampPeriod = ({ className }: { className?: string }) => (
+export const StampPeriod = ({ className }: { className?: string }): React.JSX.Element => (
   <span className={cn("relative inline-block size-[0.19em] bg-primary mx-[0.08em]", className)}>
     {/* The period stays in the text so copy/paste and screen readers get the
         sentence, not a gap. sr-only is out of flow, so it can't disturb the

--- a/components/stamp-period.tsx
+++ b/components/stamp-period.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils"
+
+/*
+ * The mark: the red square that ends the hero, the About and Contact titles,
+ * the 404, the sent-message confirmation, and the footer byline. It matches
+ * app/icon.svg, which is a literal square rect.
+ *
+ * Drawn rather than typeset. It used to be an Archivo period, whose glyph is
+ * square; Inter's is round and no stylistic set squares it, so the mark had to
+ * stop depending on the typeface. Now it survives any future type change.
+ *
+ * Every dimension is em-relative, so the same component serves the 72px hero
+ * and the 12px footer. The numbers are Inter's own period metrics at the
+ * display weight — 0.1875em tall on a 0.3525em advance — so the square keeps
+ * the spacing and mass of the glyph it replaces. It sits flat on the baseline
+ * rather than dipping below it the way the round dot does: overshoot is an
+ * optical correction for curves, and a square that used it would read as
+ * sunken.
+ */
+export const StampPeriod = ({ className }: { className?: string }) => (
+  <span className={cn("relative inline-block size-[0.19em] bg-primary mx-[0.08em]", className)}>
+    {/* The period stays in the text so copy/paste and screen readers get the
+        sentence, not a gap. sr-only is out of flow, so it can't disturb the
+        box's baseline alignment. */}
+    <span className="sr-only">.</span>
+  </span>
+)

--- a/lib/scroll-flow-math.ts
+++ b/lib/scroll-flow-math.ts
@@ -38,16 +38,19 @@ export interface RecedeStyle {
 const TALL_VIEWPORT = 900
 const SHORT_VIEWPORT = 700
 /* No ramp shorter than this, however squat the window — below roughly a line
- * and a half of scroll the rise stops reading as motion and starts reading as
- * a pop */
-export const MIN_RAMP_HEIGHT = 64
+ * of scroll the rise stops reading as motion and starts reading as a pop.
+ * Scaled down with the ramp fractions below; left at 64 it became the binding
+ * constraint on every viewport under ~740px, which flattened the tightening
+ * that enterRamp exists to do. */
+export const MIN_RAMP_HEIGHT = 44
 /*
  * How far an element rises on its way in, as a share of the ramp it rises
  * over. A share rather than a fixed distance because the two compose: the
  * element climbs its own rise on top of the page's scroll, so a constant
  * distance over a variable ramp would make the same content overshoot faster
- * on a phone than on a desktop. The ratio is the one a full-height window has
- * always had — 32px across a 180px ramp — now held everywhere.
+ * on a phone than on a desktop. The ratio comes from the geometry a full-height
+ * window originally had — 32px of rise across a 180px ramp — and is now held
+ * everywhere, so shortening the ramp shortens the rise with it.
  */
 const RISE_RATIO = 32 / 180
 
@@ -63,21 +66,22 @@ export const clamp01 = (value: number): number => Math.min(1, Math.max(0, value)
 /*
  * Where the enter ramp starts and how long it runs, in pixels.
  *
- * Both used to be flat fractions of the viewport: begin at 0.96, finish 0.2
- * later. On a full-height window that is a comfortable runway — a fifth of the
- * screen to arrive in, settling a quarter of the way up. On a phone the same
- * fractions describe most of what the reader can see at once: the lowest ~150px
- * never resolved, and with the browser's own chrome sitting under them the page
- * read as cut off rather than as in motion.
+ * The start is a flat fraction of the viewport that tightens as the window
+ * shortens — the ramp begins nearer the bottom edge on a phone, where the
+ * lowest ~150px otherwise never resolved and the page read as cut off rather
+ * than as in motion under the browser's own chrome.
  *
- * So the fractions tighten as the viewport shortens — the ramp finishes nearer
- * the bottom edge and spends less of the screen getting there — while a tall
- * window keeps exactly the geometry it has always had.
+ * The ramp height tightens on the same curve. It used to run a fifth of a
+ * full-height screen, which put a tall band of half-blurred, half-faded
+ * content along the bottom edge on every scroll — enough of the viewport that
+ * the softening read as a permanent state rather than as an arrival. Cut to
+ * roughly 0.6 of that, so content is resolved well before it reaches reading
+ * height and the ramp is something you pass through instead of sit in.
  */
 export const enterRamp = (viewportHeight: number): EnterRamp => {
   const shortness = clamp01((TALL_VIEWPORT - viewportHeight) / (TALL_VIEWPORT - SHORT_VIEWPORT))
   const startFraction = 0.96 + 0.04 * shortness
-  const rampFraction = 0.2 - 0.1 * shortness
+  const rampFraction = 0.12 - 0.06 * shortness
 
   return {
     start: viewportHeight * startFraction,


### PR DESCRIPTION
This PR consolidates the site&#39;s typography to a single typeface (Inter) and refines the scroll entrance ramp behavior for improved readability across viewport sizes.

## Summary
Replaces the multi-face type system (Archivo + Space Grotesk) with Inter throughout the site, and adjusts scroll animation parameters to prevent content from appearing overly softened on smaller viewports.

## Key Changes

**Typography Migration:**
- Removed Archivo and Space Grotesk font imports; now using only Inter as a variable font
- Updated all font token references (`--font-sans`, `--font-heading`, `--font-mono`) to resolve to Inter
- Kept three separate font tokens for semantic clarity and future flexibility, even though they all point to the same face
- Removed the `--font-display` token: Tailwind v4 only emits a `@theme` variable that some generated utility actually references, and nothing in this codebase uses a `font-display` utility, so the token shipped as an empty string. `.title-display` now uses the emitted `--font-heading` token instead — that is the token this codebase genuinely uses for display type (section labels, case-study titles, stat values), so a future display face set there actually reaches the hero headings
- Updated comments and documentation to reflect the single-face system

**Scroll Ramp Refinement:**
- Reduced `MIN_RAMP_HEIGHT` from 64px to 44px to prevent it from becoming a binding constraint on viewports under ~740px
- Adjusted `rampFraction` calculation from `0.2 - 0.1 * shortness` to `0.12 - 0.06 * shortness`, narrowing the entrance band on all viewport sizes
- This ensures content resolves well before reaching reading height and the ramp becomes something users pass through rather than sit in
- Updated test expectations and added assertion to verify content is resolved by 80% viewport height

**Component Extraction:**
- Created new `StampPeriod` component to replace inline period marks throughout the site
- The component renders a square red mark (matching `app/icon.svg`) using em-relative sizing for consistent scaling across different text sizes
- Includes screen reader text for accessibility and proper baseline alignment
- Replaced all instances in hero titles, footer, 404 page, and contact confirmation with the new component

**Typography Refinements:**
- Adjusted stat value sizing in portfolio grid (`text-lg sm:text-[14px] md:text-[18px] lg:text-[26px]`) with responsive tracking to maintain intended display weight appearance
- Added detailed comment explaining the responsive sizing strategy for the stats section

## Implementation Details
- Inter is served as a variable font from Google Fonts, providing the full 100–900 weight range in a single file
- The `StampPeriod` component uses `sr-only` for the text period to maintain copy/paste and screen reader functionality while displaying the visual mark
- All font-family references updated from Archivo/Space Grotesk to Inter with appropriate fallbacks
- Removed webkit font smoothing note specific to the old typefaces; updated to reference Inter&#39;s rendering characteristics
- Constraint worth knowing for future edits: `--font-heading` stays emitted only while some markup uses a `font-heading` utility

https://claude.ai/code/session_01TmaD3yRnLqiednW7QeqQwn