### PR TITLE
Redesign selected work cards to display full-width on desktop

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -185,19 +185,16 @@ export default function Portfolio() {
           <SectionLabel title="Selected Work" counter="04" />
         </div>
 
-        {/* Selected work runs one full-width plate per row so the four career
-            projects visibly outrank the Other Work grid below. data-flow rides
-            a wrapper rather than the card itself so the card keeps sole
-            ownership of its own hover transform. */}
+        {/* Selected work runs one card per row so the four career projects'
+            screenshots land at full container width and visibly outrank the
+            Other Work grid below. data-flow rides a wrapper rather than the
+            card itself so the card keeps sole ownership of its own hover
+            transform. */}
         <div className="grid grid-cols-1 gap-6">
           {selectedWork.map((project, index) => (
             <div key={project.title} data-flow={flowStagger[index % flowStagger.length]} className="h-full">
-              {/* Only the first plate is above the fold; the rest lazy-load */}
-              <WorkCard
-                {...project}
-                priority={index === 0}
-                counter={`0${index + 1} / 0${selectedWork.length}`}
-              />
+              {/* Only the first card is above the fold; the rest lazy-load */}
+              <WorkCard {...project} priority={index === 0} />
             </div>
           ))}
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -185,13 +185,19 @@ export default function Portfolio() {
           <SectionLabel title="Selected Work" counter="04" />
         </div>
 
-        {/* data-flow rides a wrapper rather than the card itself so the card
-            keeps sole ownership of its own hover transform */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Selected work runs one full-width plate per row so the four career
+            projects visibly outrank the Other Work grid below. data-flow rides
+            a wrapper rather than the card itself so the card keeps sole
+            ownership of its own hover transform. */}
+        <div className="grid grid-cols-1 gap-6">
           {selectedWork.map((project, index) => (
             <div key={project.title} data-flow={flowStagger[index % flowStagger.length]} className="h-full">
-              {/* Preload only the first row (two cards); the rest lazy-load */}
-              <WorkCard {...project} priority={index < 2} />
+              {/* Only the first plate is above the fold; the rest lazy-load */}
+              <WorkCard
+                {...project}
+                priority={index === 0}
+                counter={`0${index + 1} / 0${selectedWork.length}`}
+              />
             </div>
           ))}
         </div>

--- a/components/work-card.tsx
+++ b/components/work-card.tsx
@@ -74,10 +74,11 @@ export const WorkCard = ({
   priority,
 }: WorkCardProps): React.JSX.Element => {
   const isPlate = variant === "selected"
-  /* Plates run one per row, so their screenshots render at full container
-     width right up to the 1024px cap */
+  /* Plates run one per row: full width below md, then the 16:9 mat letterboxes
+     the 3:2 screenshot to 84% of the mat width (16:9 box height × 3:2 ratio) —
+     ~80vw of the viewport, 812px once the 1024px container caps out */
   const sizes = isPlate
-    ? "(max-width: 1024px) 100vw, 1024px"
+    ? "(max-width: 768px) 100vw, (max-width: 1024px) 80vw, 812px"
     : "(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 512px"
 
   const body = (

--- a/components/work-card.tsx
+++ b/components/work-card.tsx
@@ -31,9 +31,6 @@ export interface WorkCardData {
 interface WorkCardProps extends WorkCardData {
   variant?: "selected" | "other"
   priority?: boolean
-  /* Red index rendered above a plate title ("01 / 04") — ties each full-width
-     plate back to the section counter so the run reads as a numbered series */
-  counter?: string
 }
 
 /*
@@ -75,18 +72,13 @@ export const WorkCard = ({
   external,
   variant = "selected",
   priority,
-  counter,
 }: WorkCardProps): React.JSX.Element => {
   const isPlate = variant === "selected"
-  /* Plates run one per row on md+ with the screenshot at 3/5 of the card, so
-     the largest render is ~590px inside the 1024px container */
+  /* Plates run one per row, so their screenshots render at full container
+     width right up to the 1024px cap */
   const sizes = isPlate
-    ? "(max-width: 768px) 100vw, (max-width: 1024px) 60vw, 620px"
+    ? "(max-width: 1024px) 100vw, 1024px"
     : "(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 512px"
-
-  /* Plates split horizontally on md+ — screenshot left, spec sheet right.
-     Small cards keep the stacked block layout at every width. */
-  const rootClasses = cn(cardClasses, isPlate && "md:grid md:grid-cols-[3fr_2fr]")
 
   const body = (
     <>
@@ -95,9 +87,6 @@ export const WorkCard = ({
       <div
         className={cn(
           "bg-mockup-frame overflow-hidden border-b border-border p-2.5",
-          /* In the horizontal split the hairline moves to the shared edge, and
-             the mat centers the screenshot when the text column runs taller */
-          isPlate && "md:border-b-0 md:border-r md:flex md:items-center",
           href && transitionFrameClassByHref.get(href),
         )}
       >
@@ -118,17 +107,10 @@ export const WorkCard = ({
           />
         </div>
       </div>
-      {/* Plate text columns pin the tags to the bottom edge on md+, so the
-          title block and the tag row frame the column like a spec sheet */}
-      <div className={cn("p-5", isPlate && "md:p-8 md:flex md:flex-col md:justify-between")}>
+      <div className="p-5">
         <div className="mb-4">
-          {isPlate && counter && (
-            <span className="block text-[11px] font-semibold tracking-[0.14em] text-primary tabular-nums mb-3">
-              {counter}
-            </span>
-          )}
           {isPlate ? (
-            <h2 className="text-lg sm:text-[22px] md:text-[28px] font-heading font-bold uppercase leading-tight mb-1">
+            <h2 className="text-lg sm:text-[22px] font-heading font-bold uppercase leading-tight mb-1">
               <span className={titleWipeClasses}>{title}</span>
             </h2>
           ) : (
@@ -138,7 +120,7 @@ export const WorkCard = ({
               </LightboxTrigger>
             </h3>
           )}
-          <p className={cn("text-muted-foreground text-sm", isPlate && "md:text-[15px]")}>{description}</p>
+          <p className="text-muted-foreground text-sm">{description}</p>
         </div>
         <div className="flex flex-wrap gap-2">
           {tags.map((tag) => (
@@ -151,7 +133,7 @@ export const WorkCard = ({
 
   if (href && !external) {
     return (
-      <TransitionLink href={href} className={rootClasses}>
+      <TransitionLink href={href} className={cardClasses}>
         {body}
       </TransitionLink>
     )
@@ -159,11 +141,11 @@ export const WorkCard = ({
 
   if (href) {
     return (
-      <Link href={href} className={rootClasses} target="_blank" rel="noopener noreferrer">
+      <Link href={href} className={cardClasses} target="_blank" rel="noopener noreferrer">
         {body}
       </Link>
     )
   }
 
-  return <div className={rootClasses}>{body}</div>
+  return <div className={cardClasses}>{body}</div>
 }

--- a/components/work-card.tsx
+++ b/components/work-card.tsx
@@ -94,23 +94,30 @@ export const WorkCard = ({
             trigger button here, which made only the screenshot clickable on a
             card that looks identical to the linked ones above; the trigger now
             lives on the title and covers the whole card. */}
-        <div className="relative w-full overflow-hidden">
+        {/* Full-width plates cap the image area at 16:9 on md+ so a whole card
+            fits closer to one viewport. The 3:2 screenshot scales down to the
+            box height and centers, letting the mat letterbox the sides —
+            cropping instead would clip toolbars and controls at the edges. */}
+        <div className={cn("relative w-full overflow-hidden", isPlate && "md:aspect-video md:flex md:justify-center")}>
           <MockupImage
             src={image.src}
             alt={image.alt}
             width={1200}
             height={800}
-            className={imageClasses}
+            className={cn(imageClasses, isPlate && "md:h-full md:w-auto")}
             priority={priority}
             quality={80}
             sizes={sizes}
           />
         </div>
       </div>
-      <div className="p-5">
-        <div className="mb-4">
+      {/* Plate info bands span the card on md+ — title and description anchor
+          the left edge, tags sign off the right — so the band carries the same
+          width as the screenshot instead of captioning its corner */}
+      <div className={cn("p-5", isPlate && "md:flex md:items-center md:justify-between md:gap-8")}>
+        <div className={cn("mb-4", isPlate && "md:mb-0")}>
           {isPlate ? (
-            <h2 className="text-lg sm:text-[22px] font-heading font-bold uppercase leading-tight mb-1">
+            <h2 className="text-lg sm:text-[22px] md:text-[28px] font-heading font-bold uppercase leading-tight mb-1">
               <span className={titleWipeClasses}>{title}</span>
             </h2>
           ) : (
@@ -120,9 +127,9 @@ export const WorkCard = ({
               </LightboxTrigger>
             </h3>
           )}
-          <p className="text-muted-foreground text-sm">{description}</p>
+          <p className={cn("text-muted-foreground text-sm", isPlate && "md:text-[15px]")}>{description}</p>
         </div>
-        <div className="flex flex-wrap gap-2">
+        <div className={cn("flex flex-wrap gap-2", isPlate && "md:justify-end md:shrink-0")}>
           {tags.map((tag) => (
             <Badge key={tag}>{tag}</Badge>
           ))}

--- a/components/work-card.tsx
+++ b/components/work-card.tsx
@@ -31,6 +31,9 @@ export interface WorkCardData {
 interface WorkCardProps extends WorkCardData {
   variant?: "selected" | "other"
   priority?: boolean
+  /* Red index rendered above a plate title ("01 / 04") — ties each full-width
+     plate back to the section counter so the run reads as a numbered series */
+  counter?: string
 }
 
 /*
@@ -72,11 +75,18 @@ export const WorkCard = ({
   external,
   variant = "selected",
   priority,
+  counter,
 }: WorkCardProps): React.JSX.Element => {
   const isPlate = variant === "selected"
+  /* Plates run one per row on md+ with the screenshot at 3/5 of the card, so
+     the largest render is ~590px inside the 1024px container */
   const sizes = isPlate
-    ? "(max-width: 640px) 100vw, (max-width: 1024px) 75vw, 1024px"
+    ? "(max-width: 768px) 100vw, (max-width: 1024px) 60vw, 620px"
     : "(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 512px"
+
+  /* Plates split horizontally on md+ — screenshot left, spec sheet right.
+     Small cards keep the stacked block layout at every width. */
+  const rootClasses = cn(cardClasses, isPlate && "md:grid md:grid-cols-[3fr_2fr]")
 
   const body = (
     <>
@@ -85,6 +95,9 @@ export const WorkCard = ({
       <div
         className={cn(
           "bg-mockup-frame overflow-hidden border-b border-border p-2.5",
+          /* In the horizontal split the hairline moves to the shared edge, and
+             the mat centers the screenshot when the text column runs taller */
+          isPlate && "md:border-b-0 md:border-r md:flex md:items-center",
           href && transitionFrameClassByHref.get(href),
         )}
       >
@@ -105,10 +118,17 @@ export const WorkCard = ({
           />
         </div>
       </div>
-      <div className="p-5">
+      {/* Plate text columns pin the tags to the bottom edge on md+, so the
+          title block and the tag row frame the column like a spec sheet */}
+      <div className={cn("p-5", isPlate && "md:p-8 md:flex md:flex-col md:justify-between")}>
         <div className="mb-4">
+          {isPlate && counter && (
+            <span className="block text-[11px] font-semibold tracking-[0.14em] text-primary tabular-nums mb-3">
+              {counter}
+            </span>
+          )}
           {isPlate ? (
-            <h2 className="text-lg sm:text-[22px] font-heading font-bold uppercase leading-tight mb-1">
+            <h2 className="text-lg sm:text-[22px] md:text-[28px] font-heading font-bold uppercase leading-tight mb-1">
               <span className={titleWipeClasses}>{title}</span>
             </h2>
           ) : (
@@ -118,7 +138,7 @@ export const WorkCard = ({
               </LightboxTrigger>
             </h3>
           )}
-          <p className="text-muted-foreground text-sm">{description}</p>
+          <p className={cn("text-muted-foreground text-sm", isPlate && "md:text-[15px]")}>{description}</p>
         </div>
         <div className="flex flex-wrap gap-2">
           {tags.map((tag) => (
@@ -131,7 +151,7 @@ export const WorkCard = ({
 
   if (href && !external) {
     return (
-      <TransitionLink href={href} className={cardClasses}>
+      <TransitionLink href={href} className={rootClasses}>
         {body}
       </TransitionLink>
     )
@@ -139,11 +159,11 @@ export const WorkCard = ({
 
   if (href) {
     return (
-      <Link href={href} className={cardClasses} target="_blank" rel="noopener noreferrer">
+      <Link href={href} className={rootClasses} target="_blank" rel="noopener noreferrer">
         {body}
       </Link>
     )
   }
 
-  return <div className={cardClasses}>{body}</div>
+  return <div className={rootClasses}>{body}</div>
 }


### PR DESCRIPTION
## Summary
Redesigned the selected work section to display project cards at full container width on desktop, creating a more prominent showcase for featured projects compared to the "Other Work" grid below.

## Key Changes

**Layout & Grid**
- Changed selected work grid from 2-column (`md:grid-cols-2`) to single-column layout (`grid-cols-1`)
- Cards now span full width, making screenshots more visually prominent on desktop

**Image Sizing**
- Updated responsive image sizes for plate variant from `(max-width: 640px) 100vw, (max-width: 1024px) 75vw, 1024px` to `(max-width: 1024px) 100vw, 1024px`
- Added aspect ratio constraint (`md:aspect-video`) to maintain 16:9 ratio on medium+ screens
- Image now scales to fit container height while maintaining aspect ratio (`md:h-full md:w-auto`), allowing the mat to letterbox sides rather than cropping content

**Info Band Layout**
- Redesigned info section (title, description, tags) to display horizontally on desktop (`md:flex md:items-center md:justify-between`)
- Title increases to `md:text-[28px]` on desktop for better visual hierarchy
- Description text scales to `md:text-[15px]`
- Tags align to the right edge (`md:justify-end`) and don't shrink (`md:shrink-0`)
- Spacing adjusted to accommodate new layout with `md:gap-8` between content groups

**Image Loading**
- Optimized preload strategy: only the first card is prioritized (`priority={index === 0}`) instead of the first two, since only one card is above the fold in the new single-column layout

## Implementation Details
- Added comprehensive comments explaining the design rationale for aspect ratio constraints and letterboxing approach
- Used `cn()` utility for conditional class composition throughout
- Maintained responsive behavior with mobile-first approach

https://claude.ai/code/session_01FM7Pi4TyFTsbCcKtB7WcJE