### PR TITLE
Lead case studies with the title row, set project names in sentence case

### DIFF
--- a/app/work/corellium/page.tsx
+++ b/app/work/corellium/page.tsx
@@ -56,7 +56,7 @@ export default function CorelliumPage() {
               sizes="60px"
             />
             <div className="min-w-0 anim-rise [animation-delay:100ms]">
-              <h1 className="font-heading font-extrabold uppercase tracking-[-0.02em] text-2xl sm:text-[32px] leading-none sm:whitespace-nowrap">Corellium</h1>
+              <h1 className="font-heading font-extrabold tracking-[-0.02em] text-2xl sm:text-[32px] leading-none sm:whitespace-nowrap">Corellium</h1>
               <p className="text-[15px] text-muted-foreground mt-1.5 sm:whitespace-nowrap">
                 Mobile virtualization for cybersecurity teams
               </p>

--- a/app/work/immertec/page.tsx
+++ b/app/work/immertec/page.tsx
@@ -56,7 +56,7 @@ export default function ImmertecPage() {
               sizes="60px"
             />
             <div className="min-w-0 anim-rise [animation-delay:100ms]">
-              <h1 className="font-heading font-extrabold uppercase tracking-[-0.02em] text-2xl sm:text-[32px] leading-none sm:whitespace-nowrap">Immertec</h1>
+              <h1 className="font-heading font-extrabold tracking-[-0.02em] text-2xl sm:text-[32px] leading-none sm:whitespace-nowrap">Immertec</h1>
               <p className="text-[15px] text-muted-foreground mt-1.5 sm:whitespace-nowrap">
                 VR medical training for live surgical procedures
               </p>

--- a/app/work/immertec/page.tsx
+++ b/app/work/immertec/page.tsx
@@ -39,21 +39,13 @@ export default function ImmertecPage() {
       
       <div className="max-w-[1024px] mx-auto px-5 pt-24 pb-6 sm:pb-8 flex flex-col gap-8 sm:gap-10">
         
-        {/* Page header — full-bleed hero image in a mat frame, then title row */}
+        {/* Page header — inverted: title row and role first so a skimmer gets
+            who/what/outcome before the viewport-height hero image */}
         <header>
-          <div className="bg-mockup-frame border border-border p-3 anim-rise [view-transition-name:vt-immertec]">
-            <LightboxImage
-              src="/work/immertec/1.webp"
-              alt="Immertec platform showing a live surgical procedure with multiple participants"
-              width={1200}
-              height={800}
-              className="w-full"
-              priority
-              quality={80}
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 75vw, 1024px"
-            />
-          </div>
-          <div data-recede="meta" className="pt-6 sm:pt-7 flex flex-col sm:flex-row sm:items-center gap-4">
+          {/* The title row recedes as the case study takes over; the framed
+              hero below it is left alone because it carries the shared-element
+              name for the card→case-study morph */}
+          <div data-recede="meta" className="flex flex-col sm:flex-row sm:items-center gap-4">
             <Image
               src="/about/logos/immertec.jpeg"
               alt="Immertec logo"
@@ -77,6 +69,18 @@ export default function ImmertecPage() {
                 <Badge>Healthcare</Badge>
               </div>
             </div>
+          </div>
+          <div className="mt-6 sm:mt-7 bg-mockup-frame border border-border p-3 anim-rise [animation-delay:140ms] [view-transition-name:vt-immertec]">
+            <LightboxImage
+              src="/work/immertec/1.webp"
+              alt="Immertec platform showing a live surgical procedure with multiple participants"
+              width={1200}
+              height={800}
+              className="w-full"
+              priority
+              quality={80}
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 75vw, 1024px"
+            />
           </div>
         </header>
 

--- a/app/work/paidly/page.tsx
+++ b/app/work/paidly/page.tsx
@@ -38,21 +38,13 @@ export default function PaidlyPage() {
       
       <div className="max-w-[1024px] mx-auto px-5 pt-24 pb-6 sm:pb-8 flex flex-col gap-8 sm:gap-10">
         
-        {/* Page header — full-bleed hero image in a mat frame, then title row */}
+        {/* Page header — inverted: title row and role first so a skimmer gets
+            who/what/outcome before the viewport-height hero image */}
         <header>
-          <div className="bg-mockup-frame border border-border p-3 anim-rise [view-transition-name:vt-paidly]">
-            <LightboxImage
-              src="/work/paidly/1.webp"
-              alt="Paidly mobile app showing invoice screens"
-              width={1200}
-              height={800}
-              className="w-full"
-              priority
-              quality={80}
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 75vw, 1024px"
-            />
-          </div>
-          <div data-recede="meta" className="pt-6 sm:pt-7 flex flex-col sm:flex-row sm:items-center gap-4">
+          {/* The title row recedes as the case study takes over; the framed
+              hero below it is left alone because it carries the shared-element
+              name for the card→case-study morph */}
+          <div data-recede="meta" className="flex flex-col sm:flex-row sm:items-center gap-4">
             <Image
               src="/about/logos/paidly.jpeg"
               alt="Paidly logo"
@@ -76,6 +68,18 @@ export default function PaidlyPage() {
                 <Badge>Fintech</Badge>
               </div>
             </div>
+          </div>
+          <div className="mt-6 sm:mt-7 bg-mockup-frame border border-border p-3 anim-rise [animation-delay:140ms] [view-transition-name:vt-paidly]">
+            <LightboxImage
+              src="/work/paidly/1.webp"
+              alt="Paidly mobile app showing invoice screens"
+              width={1200}
+              height={800}
+              className="w-full"
+              priority
+              quality={80}
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 75vw, 1024px"
+            />
           </div>
         </header>
 

--- a/app/work/paidly/page.tsx
+++ b/app/work/paidly/page.tsx
@@ -55,7 +55,7 @@ export default function PaidlyPage() {
               sizes="60px"
             />
             <div className="min-w-0 anim-rise [animation-delay:100ms]">
-              <h1 className="font-heading font-extrabold uppercase tracking-[-0.02em] text-2xl sm:text-[32px] leading-none sm:whitespace-nowrap">Paidly</h1>
+              <h1 className="font-heading font-extrabold tracking-[-0.02em] text-2xl sm:text-[32px] leading-none sm:whitespace-nowrap">Paidly</h1>
               <p className="text-[15px] text-muted-foreground mt-1.5 sm:whitespace-nowrap">
                 Stripe-integrated invoicing mobile app for SMEs
               </p>

--- a/app/work/spontivly/page.tsx
+++ b/app/work/spontivly/page.tsx
@@ -40,21 +40,13 @@ export default function SpontivlyPage() {
       
       <div className="max-w-[1024px] mx-auto px-5 pt-24 pb-6 sm:pb-8 flex flex-col gap-8 sm:gap-10">
         
-        {/* Page header — full-bleed hero image in a mat frame, then title row */}
+        {/* Page header — inverted: title row and role first so a skimmer gets
+            who/what/outcome before the viewport-height hero image */}
         <header>
-          <div className="bg-mockup-frame border border-border p-3 anim-rise [view-transition-name:vt-spontivly]">
-            <LightboxImage
-              src="/work/spontivly/1.webp"
-              alt="Spontivly social analytics dashboard showing engagement metrics, impression trends, and top performing content"
-              width={1200}
-              height={800}
-              className="w-full"
-              priority
-              quality={80}
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 75vw, 1024px"
-            />
-          </div>
-          <div data-recede="meta" className="pt-6 sm:pt-7 flex flex-col sm:flex-row sm:items-center gap-4">
+          {/* The title row recedes as the case study takes over; the framed
+              hero below it is left alone because it carries the shared-element
+              name for the card→case-study morph */}
+          <div data-recede="meta" className="flex flex-col sm:flex-row sm:items-center gap-4">
             <Image
               src="/about/logos/spontivly.jpeg"
               alt="Spontivly logo"
@@ -78,6 +70,18 @@ export default function SpontivlyPage() {
                 <Badge>Analytics</Badge>
               </div>
             </div>
+          </div>
+          <div className="mt-6 sm:mt-7 bg-mockup-frame border border-border p-3 anim-rise [animation-delay:140ms] [view-transition-name:vt-spontivly]">
+            <LightboxImage
+              src="/work/spontivly/1.webp"
+              alt="Spontivly social analytics dashboard showing engagement metrics, impression trends, and top performing content"
+              width={1200}
+              height={800}
+              className="w-full"
+              priority
+              quality={80}
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 75vw, 1024px"
+            />
           </div>
         </header>
 

--- a/app/work/spontivly/page.tsx
+++ b/app/work/spontivly/page.tsx
@@ -57,7 +57,7 @@ export default function SpontivlyPage() {
               sizes="60px"
             />
             <div className="min-w-0 anim-rise [animation-delay:100ms]">
-              <h1 className="font-heading font-extrabold uppercase tracking-[-0.02em] text-2xl sm:text-[32px] leading-none sm:whitespace-nowrap">Spontivly</h1>
+              <h1 className="font-heading font-extrabold tracking-[-0.02em] text-2xl sm:text-[32px] leading-none sm:whitespace-nowrap">Spontivly</h1>
               <p className="text-[15px] text-muted-foreground mt-1.5 sm:whitespace-nowrap">
                 Analytics dashboards for non-technical users
               </p>

--- a/components/work-card.tsx
+++ b/components/work-card.tsx
@@ -59,6 +59,14 @@ const cardClasses =
 const imageClasses =
   "w-full transition-[scale] duration-700 ease-(--ease-settle) group-hover:scale-[1.03] motion-reduce:transition-none"
 
+/*
+ * Caps are for chrome — nav, section labels, meta labels, badges, captions.
+ * Project names stay in sentence case because they are other companies'
+ * wordmarks, and uppercasing flattens the ascender/descender silhouette that
+ * makes a name recognizable. The case-study h1s follow the same rule, so both
+ * title levels here and those four headings have to stay in step.
+ */
+
 /* Titles take the same wiping rule as the nav — one underline system */
 const titleWipeClasses =
   "relative inline-block after:absolute after:inset-x-0 after:-bottom-0.5 after:h-[2px] after:bg-primary after:origin-right after:scale-x-0 group-hover:after:origin-left group-hover:after:scale-x-100 after:transition-transform after:duration-(--motion-settle) after:ease-(--ease-settle) motion-reduce:after:transition-none"
@@ -118,11 +126,11 @@ export const WorkCard = ({
       <div className={cn("p-5", isPlate && "md:flex md:items-center md:justify-between md:gap-8")}>
         <div className={cn("mb-4", isPlate && "md:mb-0")}>
           {isPlate ? (
-            <h2 className="text-lg sm:text-[22px] md:text-[28px] font-heading font-bold uppercase leading-tight mb-1">
+            <h2 className="text-lg sm:text-[22px] md:text-[28px] font-heading font-bold leading-tight mb-1">
               <span className={titleWipeClasses}>{title}</span>
             </h2>
           ) : (
-            <h3 className="text-base sm:text-lg font-heading font-bold uppercase leading-tight mb-1">
+            <h3 className="text-base sm:text-lg font-heading font-bold leading-tight mb-1">
               <LightboxTrigger src={image.src} alt={image.alt} width={1200} height={800}>
                 <span className={titleWipeClasses}>{title}</span>
               </LightboxTrigger>

--- a/components/work-card.tsx
+++ b/components/work-card.tsx
@@ -59,14 +59,6 @@ const cardClasses =
 const imageClasses =
   "w-full transition-[scale] duration-700 ease-(--ease-settle) group-hover:scale-[1.03] motion-reduce:transition-none"
 
-/*
- * Caps are for chrome — nav, section labels, meta labels, badges, captions.
- * Project names stay in sentence case because they are other companies'
- * wordmarks, and uppercasing flattens the ascender/descender silhouette that
- * makes a name recognizable. The case-study h1s follow the same rule, so both
- * title levels here and those four headings have to stay in step.
- */
-
 /* Titles take the same wiping rule as the nav — one underline system */
 const titleWipeClasses =
   "relative inline-block after:absolute after:inset-x-0 after:-bottom-0.5 after:h-[2px] after:bg-primary after:origin-right after:scale-x-0 group-hover:after:origin-left group-hover:after:scale-x-100 after:transition-transform after:duration-(--motion-settle) after:ease-(--ease-settle) motion-reduce:after:transition-none"
@@ -125,6 +117,12 @@ export const WorkCard = ({
           width as the screenshot instead of captioning its corner */}
       <div className={cn("p-5", isPlate && "md:flex md:items-center md:justify-between md:gap-8")}>
         <div className={cn("mb-4", isPlate && "md:mb-0")}>
+          {/* Caps are for chrome — nav, section labels, meta labels, badges,
+              captions. Project names stay in sentence case because they are
+              other companies' wordmarks, and uppercasing flattens the
+              ascender/descender silhouette that makes a name recognizable. The
+              case-study h1s follow the same rule, so both title levels here and
+              those four headings have to stay in step. */}
           {isPlate ? (
             <h2 className="text-lg sm:text-[22px] md:text-[28px] font-heading font-bold leading-tight mb-1">
               <span className={titleWipeClasses}>{title}</span>


### PR DESCRIPTION
Two related typography/layout fixes to the case studies and work cards.

## 1. Lead every case study with the title row

Paidly, Immertec and Spontivly opened with the full-bleed hero image and put the title, role and tags *underneath* it. Corellium already ran the other way round — title row first, then the framed hero. All four now lead with who/what/outcome.

**The layout bug behind it.** The old order was fighting the scroll-flow engine, so this is a functional fix and not only a visual one. `computeRecede` in `lib/scroll-flow-math.ts` is a pure function of `scrollY`:

```ts
const progress = clamp01(scrollY / (viewportHeight * 0.9))
opacity: isMeta ? 1 - progress : ...
```

It fades `[data-recede="meta"]` to opacity 0 by ~90% of a viewport height of scrolling. That's correct when the meta sits at the top of the page (Corellium): visible on load, receding as the case study takes over. Below a viewport-tall hero, though, the fade is keyed to scroll distance the reader has *already travelled* to reach it — so the title row had faded out by the time it scrolled into view. The title and role were unreadable at the exact moment you got to them.

For each of `app/work/paidly`, `app/work/immertec`, `app/work/spontivly`:

- Moved the `[data-recede="meta"]` title row above the framed hero
- Dropped `pt-6 sm:pt-7` from the title row; the hero now carries `mt-6 sm:mt-7`
- Added `[animation-delay:140ms]` to the hero's `anim-rise` so it lands behind the logo/title/role rise, matching Corellium's cadence

The hero frames keep their `[view-transition-name:vt-*]`, so the card→case-study morph is untouched.

## 2. Project names in sentence case

Caps were doing two different jobs on the site. On chrome — nav, `01 / OVERVIEW` section labels, 11px meta labels, badges, buttons, figure captions, footer — it reads as a deliberate system and stays. On project names it fought the content: these are other companies' wordmarks, and uppercasing flattens the ascender/descender silhouette that makes a name recognizable, so `SPONTIVLY` is a harder read than `Spontivly`.

The rule is now **caps for chrome, sentence case for proper nouns**:

- Dropped `uppercase` from both `work-card.tsx` title levels (the plate `h2` and the small `h3`), covering Selected Work and Other Work
- Dropped it from the four case-study `h1`s, so a name renders identically on the index and its detail page
- Added a comment in `work-card.tsx` recording the split, since the rule now spans six spots that have to stay in step

The wordmark in `header.tsx` deliberately keeps its caps — a logotype is an identity mark, not running content.

Data was already stored sentence-case in `selectedWork`/`otherWork` and `lib/metadata.ts`; only the display was transformed. No accessibility change either way, since `text-transform` doesn't affect what screen readers announce.

## Verification

- `pnpm lint` — clean
- `tsc --noEmit` — clean
- `pnpm test` — 65/65 passing
- `pnpm build` — all 12 routes prerender
- Checked the rendered DOM: each case-study header is now `TITLE-ROW then HERO-IMAGE`, and computed `text-transform` on the home page is `uppercase` for the two section labels and `none` for all seven project names