### PR TITLE
Bump undici override to 7.29.0 to clear five security advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
       "@isaacs/brace-expansion": ">=5.0.1",
       "minimatch": ">=10.2.3",
       "postcss": ">=8.5.10",
-      "undici": "7.28.0",
+      "undici": "7.29.0",
       "esbuild": "0.28.1",
       "sharp": ">=0.35.0",
       "ws": ">=8.21.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@isaacs/brace-expansion': '>=5.0.1'
   minimatch: '>=10.2.3'
   postcss: '>=8.5.10'
-  undici: 7.28.0
+  undici: 7.29.0
   esbuild: 0.28.1
   sharp: '>=0.35.0'
   ws: '>=8.21.0'
@@ -3093,8 +3093,8 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -5451,7 +5451,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5639,7 +5639,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.0
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260611.1
       ws: 8.21.1
       youch: 4.1.0-beta.10
@@ -6227,7 +6227,7 @@ snapshots:
 
   undici-types@6.19.8: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
## Summary

Bumps the `undici` pnpm override from `7.28.0` to `7.29.0`, clearing five open Dependabot alerts (1 high, 4 moderate).

The repo already forced a single `undici` version across the tree via `pnpm.overrides`, so every dependent resolved to the same affected copy — one bump closes all five alerts rather than needing per-alert changes.

## Advisories resolved

| Advisory | Severity | Issue |
|---|---|---|
| [GHSA-4cwx-7wf7-3272](https://github.com/nodejs/undici/security/advisories/GHSA-4cwx-7wf7-3272) | High | Cross-user information disclosure + parse-time crash via degenerate private cache directives |
| [GHSA-jr45-8vmc-qm54](https://github.com/nodejs/undici/security/advisories/GHSA-jr45-8vmc-qm54) | Moderate | Cross-user information disclosure via whitespace around `=` in Cache-Control directives |
| [GHSA-8xcm-r25x-g524](https://github.com/nodejs/undici/security/advisories/GHSA-8xcm-r25x-g524) | Moderate | Downstream response desynchronization via the retry interceptor |
| [GHSA-v3r7-h72x-cjcm](https://github.com/nodejs/undici/security/advisories/GHSA-v3r7-h72x-cjcm) | Moderate | Cookie attribute injection via unsanitized domain and unparsed `setCookie` fields |
| [GHSA-m8rv-5g2x-5cg5](https://github.com/nodejs/undici/security/advisories/GHSA-m8rv-5g2x-5cg5) | Moderate | CRLF injection via blob-like body `type` property |

All five are patched in 7.29.0.

## Scope of exposure

`undici` is a development-scope dependency here, reached two ways:

- `jsdom@29.0.1` — the vitest test environment
- `miniflare@4.x` — pulled in via `wrangler`

Neither path reaches the deployed site, so practical exposure was low. The fix is a clean minor bump, so there's no reason to carry the alerts.

## Why 7.29.0 and not 8.x

`undici@8.10.0` is the current latest, but 7.29.0 is the last release on the 7.x line and is fully patched for all five advisories. Staying on 7.x avoids pushing `jsdom` and `miniflare` onto a major neither declares support for — no added security benefit, real breakage risk. It also keeps the exact-version pinning the repo's dependency rules call for.

## Verification

- `pnpm install --frozen-lockfile` — clean
- `pnpm test` — 65/65 passing across 6 files
- `pnpm lint` — zero warnings/errors
- `pnpm build` — succeeds, all 12 routes prerendered
- `node_modules/.pnpm` contains exactly one undici (`7.29.0`), confirming no unpatched duplicate remains

The lockfile diff touches only the override and the four `undici` references — nothing else moved.